### PR TITLE
viper: added linux ARM build support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <packaging>pom</packaging>
 
     <properties>
-      <tycho-version>2.6.0</tycho-version>
+      <tycho-version>4.0.7</tycho-version>
       <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
       <eclipse-repo.url>https://download.eclipse.org/releases/2022-12</eclipse-repo.url>
     </properties>
@@ -56,6 +56,11 @@
                             <os>macosx</os>
                             <ws>cocoa</ws>
                             <arch>x86_64</arch>
+                        </environment>
+                        <environment>
+                            <os>linux</os>
+                            <ws>gtk</ws>
+                            <arch>aarch64</arch>
                         </environment>
                     </environments>
                 </configuration>


### PR DESCRIPTION
The tycho version bump is due to an issue I was incurring in that was solved after 4.0.1: [https://github.com/eclipse-tycho/tycho/discussions/3738](https://github.com/eclipse-tycho/tycho/discussions/3738). 

I've tested the changes on x86_64 Linux, Windows, and aarch64 Linux.

On Ubuntu24.04, the version from the default APT repositories is too old to support tycho >4.0.0, but maven is portable and the last version on https://maven.apache.org/download.cgi builds viper just fine.