### PR TITLE
fix(session): use host & port props for equality check

### DIFF
--- a/bundles/org.vcml.session/src/org/vcml/session/Session.java
+++ b/bundles/org.vcml.session/src/org/vcml/session/Session.java
@@ -35,8 +35,6 @@ public class Session {
 
     public final static String ANNOUNCE_DIR = System.getProperty("java.io.tmpdir");
 
-    private String uri = "";
-
     private String host = "";
 
     private int port = 0;
@@ -64,10 +62,6 @@ public class Session {
     private boolean running = false;
 
     private String stopReason = "";
-
-    public String getURI() {
-        return uri;
-    }
 
     public String getHost() {
         return host;
@@ -147,7 +141,7 @@ public class Session {
             return false;
 
         Session session = (Session) other;
-        return uri.equals(session.getURI());
+        return port == session.port && host.equals(session.host);
     }
 
     private void updateVersion() throws SessionException {


### PR DESCRIPTION
Remove not set & unused `uri` property and use the `host` and `port`
properties for an equality check instead.

The `getAvailableSessions` function looks for available VSP sessions via
announcement files and checks if the session is already known before
adding it to the list. This check is performed by comparing the `uri`
property of the session instances. However, since this property was always
an empty string, the comparison always returned true, and ViPER only
added one session from the announcement files.
